### PR TITLE
feature: iam.shortcuts.allow_or_raise_auth_failed 支持使用 cache 判断 (#28)

### DIFF
--- a/iam/__version__.py
+++ b/iam/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "1.1.13"
+__version__ = "1.1.14"

--- a/iam/shortcuts.py
+++ b/iam/shortcuts.py
@@ -10,15 +10,14 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-
 from . import Request
 from .exceptions import AuthFailedException
 
 
-def allow_or_raise_auth_failed(iam, system, subject, action, resources, environment=None):
+def allow_or_raise_auth_failed(iam, system, subject, action, resources, environment=None, cache=False):
     request = Request(system, subject, action, resources, environment)
 
-    allowed = iam.is_allowed(request)
+    allowed = iam.is_allowed_with_cache(request) if cache else iam.is_allowed(request)
 
     if not allowed:
         raise AuthFailedException(system, subject, action, resources)

--- a/release.md
+++ b/release.md
@@ -1,5 +1,9 @@
 版本日志
 ===============
+
+# v1.1.14
+
+- add: iam.shortcuts.allow_or_raise_auth_failed 支持使用 cache 判断
 # v1.1.13
 
 - add: iam_migration 如果配置了BK_IAM_SKIP，则不进行migrate


### PR DESCRIPTION
* feature: iam.shortcuts.allow_or_raise_auth_failed 支持使用 cache 判断

* minor: version bump to 1.1.14